### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "web": "http://github.com/arcturus",
     "twitter": "mepartoconmigo"
   },
-  "license": {
-    "type": "Apache 2.0"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "http://github.com/arcturus/node-firefoxos-cli.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
